### PR TITLE
fixed relative path bug in data_downloader.py script

### DIFF
--- a/src/data/data_downloader.py
+++ b/src/data/data_downloader.py
@@ -2,11 +2,12 @@ import os.path as path
 import wget
 import zipfile
 
+dirname = path.dirname(__file__)
 ## Data will be downloaded in the folder data/raw/
-data_download_path =  path.abspath(path.join("../../data/raw"))
+data_download_path =   path.join(dirname, "../../data/raw")
 ## We are downloading the mysql.zip file and storing it in folder data/raw
 wget.download("https://github.com/SankBad/configuration_datasets/raw/master/configfiles/mysql/mysql.zip", data_download_path)
 ## We are unzipping the file inside the data/raw
-with zipfile.ZipFile("../../data/raw/mysql.zip", 'r') as zip_ref:
+with zipfile.ZipFile(data_download_path+"/mysql.zip", 'r') as zip_ref:
     zip_ref.extractall(data_download_path)
 


### PR DESCRIPTION
The current, script only works if we run it from the folder in which it is located. 
This PR will fix this issue. 