### PR TITLE
Restructure docs to match opf format

### DIFF
--- a/docs/blog/configuration-file-analysis-blog.md
+++ b/docs/blog/configuration-file-analysis-blog.md
@@ -113,23 +113,4 @@ In this project, we discovered frequently occurring patterns in MySQL configurat
 
 \[8\] [https://haydenjames.io/mysql-query-cache-size-performance/](https://haydenjames.io/mysql-query-cache-size-performance/)
 
-# Project Materials
-
-### Steps to get you started:
-
-1. Visit [https://jupyterhub-opf-jupyterhub.apps.cnv.massopen.cloud/hub/login](https://jupyterhub-opf-jupyterhub.apps.cnv.massopen.cloud/hub/login)
-
-2. You can login by using your Google account.
-
-3. In this Spawn screen, select configuration-files-analysis:latest, in the memory size select Large
-
-4. Once your server starts, go into the directory named notebooks-yyyy-mm-dd-hh-mm
-
-### How to Contribute / Provide feedback
-
-* Github Repository: [https://github.com/aicoe-aiops/configuration-files-analysis](https://github.com/aicoe-aiops/configuration-files-analysis)
-
-* You can open up a PR on the Git Repository highlighting the feature or issue, and we will address it.
-
-* You can also reach out to sbadhe@redhat.com for any questions.
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -1,0 +1,14 @@
+
+# Content
+
+## Blog
+
+Check out the [project blog](blog/configuration-file-analysis-blog.md) page which goes over the details of the project.
+
+## Notebooks
+
+1. [Demo](../notebooks/Configuration_file_analysis_demo.ipynb)
+
+2. [Data type errors](../notebooks/Misconfiguration_detection_framework_for_data_type_errors.ipynb)
+
+3. [Spelling errors](../notebooks/Misconfiguration_detection_framework_for_spelling_errors.ipynb)

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,0 +1,7 @@
+# Contribute to the Configuration Files Analysis Project
+
+To get started with familiarizing yourself with the Configuration Files Analysis project, check how to [Get Started](get-started.md).
+
+1. If you have any notebooks to contribute towards this project, please [open an issue](https://github.com/aicoe-aiops/configuration-files-analysis/issues) on project's [Github Repository](https://github.com/aicoe-aiops/configuration-files-analysis)
+2. If you have any questions, or feature requests, you can [open up a PR](https://github.com/aicoe-aiops/configuration-files-analysis/pulls) on the Git Repository highlighting the feature or issue.
+3. You can also reach out to aicoe-aiops@redhat.com for any questions.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,16 @@
+# Get Started
+
+This project discusses how we can find misconfigurations in configuration files. Check out the [content page](content.md) for a detailed overview of this project.
+
+## Try it out yourself
+
+There are interactive and reproducible notebooks for this entire [project](https://github.com/aicoe-aiops/configuration-files-analysis) available for anyone to start using on the public [JupyterHub](https://jupyterhub-opf-jupyterhub.apps.zero.massopen.cloud/hub/login) instance on the [Massachusetts Open Cloud](https://massopen.cloud/) (MOC) right now!
+
+1. To get started, access [JupyterHub](https://jupyterhub-opf-jupyterhub.apps.zero.massopen.cloud/), select log in with `moc-sso` and sign in using your Google Account.
+2. After signing in, on the spawner page, please select the `Configuration File Analysis Notebook Image` in the JupyterHub Notebook Image section from the dropdown and select a `Medium` container size and hit `Start` to start your server.
+3. Once your server has spawned, you should see a directory titled `s2i-configuration-files-analysis-<current-timestamp>`.
+4. Go to `notebooks` and run the notebook you want to experiment with.
+5. Check out the detailed [content](content.md) page with project blog and notebooks.
+
+
+If you need more help navigating the Operate First environment, we have a few [short videos](https://www.youtube.com/playlist?list=PL8VBRDTElCWpneB4dBu4u1kHElZVWfAwW) to help you get started.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,18 @@
+---
+title: Configuration file analysis
+description: misconfigurations detection by discovering frequently occurring patterns in configuration files
+---
+
+Software systems have become more flexible and feature-rich. The configuration file for MySQL has more than 200 configuration entries with different subentries.  As a result, configuring these systems is a complicated task and frequently causes configuration errors. These errors are one of the major underlying causes of modern software system failures [[1](http://cseweb.ucsd.edu/~tixu/papers/csur.pdf)]. In 2017, AT&T’s  911 service went down for 5 hours because of a system configuration change [[2](https://thehill.com/policy/technology/325510-over-12000-callers-couldnt-reach-911-during-att-outage)]. About 12600 unique callers were not able to reach 911 during that period. In another similar incident, Facebook and Instagram went down because of a change that affected facebook’s configuration systems [[3](https://mashable.com/2015/01/27/facebook-tinder-instagram-issues/)]. These critical system failures are ubiquitous - In one empirical study, researchers found that the percentage of system failure caused by configuration errors is higher than the percentage of failure resulting from bugs, 30% and 20% respectively [[4](https://atg.netapp.com/wp-content/uploads/2011/10/sosp11-yin.pdf)]. 
+
+Some of the configuration files are written by experts and customized by users such as RHEL tuned files, while others are completely configured by end-users. When writing configuration files, users usually take existing files and modify them with little knowledge of the system. The non-expert user can then easily introduce errors. Even worse, the original file may already be corrupted, and the errors are propagated further. In a lot of these cases, misconfigurations are detected by manually specified rules. However, this process is tedious and not scalable. In this project, we propose data-driven methods to detect misconfigurations by discovering frequently occurring patterns in configuration files. 
+
+* **[Get Started](get-started.md)**
+
+* **[How to Contribute](contribute.md)**
+
+* **[Project Content](content.md)**
+
+## Contact
+
+This project is maintained as part of the AIOps team in Red Hat’s AI CoE as part of the Office of the CTO. More information can be found at https://www.operate-first.cloud/.


### PR DESCRIPTION
 For issue https://github.com/operate-first/operate-first.github.io/issues/272, restructure project docs to match the standard opf format.